### PR TITLE
feat: add Chakra color manager for SSR

### DIFF
--- a/src/lib/chakra.tsx
+++ b/src/lib/chakra.tsx
@@ -1,0 +1,31 @@
+import {
+	ChakraProvider as BaseChakraProvider,
+	type ChakraProviderProps as BaseChakraProviderProps,
+	cookieStorageManagerSSR,
+	localStorageManager,
+} from "@chakra-ui/react";
+import { type GetServerSideProps } from "next";
+
+type ChakraProviderProps = Omit<BaseChakraProviderProps, "colorModeManager"> & {
+	readonly cookies?: string;
+};
+
+export const ChakraProvider = ({ cookies, ...props }: ChakraProviderProps) => {
+	const colorModeManager =
+		typeof cookies === "string"
+			? cookieStorageManagerSSR(cookies)
+			: localStorageManager;
+
+	return <BaseChakraProvider colorModeManager={colorModeManager} {...props} />;
+};
+
+export type ChakraPageProps = {
+	readonly cookies: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const getServerSideProps = (async ({ req: request }) => ({
+	props: {
+		cookies: request.headers.cookie ?? "",
+	},
+})) satisfies GetServerSideProps<ChakraPageProps>;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,11 @@
 import type { AppProps } from "next/app";
 
 import { PageContainer } from "@/components/PageContainer";
+import { type ChakraPageProps } from "@/lib/chakra";
 import { AppProvider } from "@/providers/app";
 
-const App = ({ Component, pageProps }: AppProps) => (
-	<AppProvider>
+const App = ({ Component, pageProps }: AppProps<ChakraPageProps>) => (
+	<AppProvider cookies={pageProps.cookies}>
 		<PageContainer>
 			<Component {...pageProps} />
 		</PageContainer>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,5 @@
 import { HomePage } from "@/features/pages/home";
 
+export { getServerSideProps } from "@/lib/chakra";
+
 export default HomePage;

--- a/src/providers/app.tsx
+++ b/src/providers/app.tsx
@@ -1,12 +1,15 @@
-import { ChakraProvider } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 
+import { ChakraProvider } from "@/lib/chakra";
 import { theme } from "@/theme";
 
 type AppProviderProps = {
+	readonly cookies: string;
 	readonly children: ReactNode;
 };
 
-export const AppProvider = ({ children }: AppProviderProps) => (
-	<ChakraProvider theme={theme}>{children}</ChakraProvider>
+export const AppProvider = ({ cookies, children }: AppProviderProps) => (
+	<ChakraProvider cookies={cookies} theme={theme}>
+		{children}
+	</ChakraProvider>
 );


### PR DESCRIPTION
This PR adds Chakra support for Next.js SSR, specifically preventing a flash of the incorrect color theme when the page first hydrates.