### PR TITLE
Fix invalid LinkedIn link

### DIFF
--- a/routes/home/index.tsx
+++ b/routes/home/index.tsx
@@ -12,7 +12,7 @@ const Home = ({}: PageProps) => (
       {" "}
       <ExternalLink href="//desmos.com">Desmos Studio.</ExternalLink>{" "}
       Check me out on{" "}
-      <ExternalLink href="//linkedin.com/spencer-berenson">
+      <ExternalLink href="//linkedin.com/in/spencer-berenson">
         LinkedIn
       </ExternalLink>{" "}
       and{" "}


### PR DESCRIPTION
This PR fixes an invalid LinkedIn link which was missing `/in/` before the profile name.